### PR TITLE
fix/background-scene-logic

### DIFF
--- a/libs/shared/phaser-singleton/src/lib/scenes/world.scene.ts
+++ b/libs/shared/phaser-singleton/src/lib/scenes/world.scene.ts
@@ -17,7 +17,6 @@ export class WorldScene extends Phaser.Scene {
     private bushesBackgroundAsset = 'assets/city-scene/bushes-day.png'; // * Asset url relative to the app itself
     private bushesBackgroundKey = 'bushes-key'; // * Store the background image name
     private floorGroup: Phaser.Physics.Arcade.StaticGroup; // * Group of sprites for the floor
-    private bushesGroup: Phaser.Physics.Arcade.StaticGroup; // * Group of sprites for the bushes background
     private obstaclesGroup: Phaser.Physics.Arcade.Group; // * Group of sprites for the obstacles
     private playerGroup: Phaser.Physics.Arcade.Group; // * Group of sprites for the obstacles
     private player: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody; // * Player to be used
@@ -160,7 +159,7 @@ export class WorldScene extends Phaser.Scene {
         this.showInfiniteBackgrounds();
         this.evaluateMovement();
         this.avoidOutOfBounds();
-        // this.obstaclesCreation();
+        this.obstaclesCreation();
         this.obstacleDetectionAndCleanUp();
     }
 


### PR DESCRIPTION
# Pull request type

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, renaming)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] Documentation content changes
-   [ ] E2E Test(s)
-   [ ] Other (please describe):

# What is the current behavior?
Backgrounds were cutting off the screen before generate again

# What is the new behavior?
fix(): fixed bushes and city background infinite movement

# Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

# Other information

https://github.com/openforge/rock-the-steps-app/assets/27866316/470ce3ca-4bf9-47ea-890b-df85d3097f85


