### PR TITLE
fix(world): add logic to prevent stacking more health after max

### DIFF
--- a/libs/shared/data-access-model/src/lib/constants/game-units.constants.ts
+++ b/libs/shared/data-access-model/src/lib/constants/game-units.constants.ts
@@ -14,6 +14,7 @@ export const INITIAL_HEALTHBAR_Y = 50;
 export const HALF_DIVIDER = 2;
 export const MOVING_X_BACKGROUNDS = 2;
 export const DAMAGE_MAX_VALUE = 5;
+export const DAMAGE_MIN_VALUE = 0;
 export const DURATION_INVULNERABLE_REP = 200;
 export const INVULNERABLE_REPS = 15;
 export const WORLD_OBJECTS_VELOCITY = 130;

--- a/libs/shared/phaser-singleton/src/lib/scenes/world.scene.ts
+++ b/libs/shared/phaser-singleton/src/lib/scenes/world.scene.ts
@@ -9,6 +9,7 @@ import {
     CityBackground,
     CONTROLS_KEY,
     DAMAGE_MAX_VALUE,
+    DAMAGE_MIN_VALUE,
     DAMAGE_TIMER,
     END_KEY,
     END_OBJECT_SCALE,
@@ -217,7 +218,7 @@ export class WorldScene extends Phaser.Scene {
                     // console.log(`COLLISION ${worldObject.name}`, playerXEnd >= worldObjectXStart, playerXStart <= worldObjectXEnd, playerYBelow >= worldObjectYAbove);
                     // console.log('DAMAGE BOUNDS', playerXEnd, worldObjectXStart, playerXStart, worldObjectXEnd, playerYBelow, worldObjectYAbove);
                     if (playerXEnd >= worldObjectXStart && playerXStart <= worldObjectXEnd && playerYBelow >= worldObjectYAbove) {
-                        if (worldObject.name === Objects.CHEESESTEAK) {
+                        if (worldObject.name === Objects.CHEESESTEAK && this.damageValue > DAMAGE_MIN_VALUE) {
                             this.healUp(worldObject);
                         } else if (worldObject.name === END_KEY) {
                             // If the end is tuched send to winning screen


### PR DESCRIPTION
# Pull request type

-   [X] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, renaming)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] Documentation content changes
-   [ ] E2E Test(s)
-   [ ] Other (please describe):

# What is the current behavior?
Cheesesteaks at full health would stack and add, even though they shouldn't. So if you had full health and ran into a cheesesteak, you wouldn't take (visual) damage until you hit 2 objects.

# What is the new behavior?
You no longer can build cheesesteak health beyond the boundary. If you are at max health the function `healUp` is not called.

# Does this introduce a breaking change?

-   [ ] Yes
-   [X] No

# Other information
