### PR TITLE
fix(world): update obstacleHandler for full health cheesesteak

### DIFF
--- a/libs/shared/phaser-singleton/src/lib/scenes/world.scene.ts
+++ b/libs/shared/phaser-singleton/src/lib/scenes/world.scene.ts
@@ -311,6 +311,8 @@ export class WorldScene extends Phaser.Scene {
         console.log(`Colliding ${player.name} with ${obstacle.name}`);
         if (obstacle.name === Objects.CHEESESTEAK && this.damageValue > DAMAGE_MIN_VALUE && this.damageValue) {
             this.healUp(obstacle);
+        } else if (obstacle.name === Objects.CHEESESTEAK && this.damageValue === DAMAGE_MIN_VALUE) {
+            this.obstacleGroup.remove(obstacle);
         } else if (obstacle.name === END_KEY) {
             // If the end is touched send to winning screen
             void this.endGame(GameEnum.WIN);
@@ -319,7 +321,7 @@ export class WorldScene extends Phaser.Scene {
             obstacle.destroy();
             this.obstacleGroup.remove(obstacle);
             this.character.makeInvulnerable(this);
-        } else if (!this.character.isDamaged && !this.character.isInvulnerable) {
+        } else if (obstacle.name !== Objects.CHEESESTEAK && !this.character.isDamaged && !this.character.isInvulnerable) {
             obstacle.destroy();
             this.receiveDamage();
         }

--- a/libs/shared/phaser-singleton/src/lib/scenes/world.scene.ts
+++ b/libs/shared/phaser-singleton/src/lib/scenes/world.scene.ts
@@ -312,9 +312,10 @@ export class WorldScene extends Phaser.Scene {
         if (obstacle.name === Objects.CHEESESTEAK && this.damageValue > DAMAGE_MIN_VALUE && this.damageValue) {
             this.healUp(obstacle);
         } else if (obstacle.name === Objects.CHEESESTEAK && this.damageValue === DAMAGE_MIN_VALUE) {
+            // * If object is a cheesesteak and the player is at full heath, do nothing
             this.obstacleGroup.remove(obstacle);
         } else if (obstacle.name === END_KEY) {
-            // If the end is touched send to winning screen
+            // * If the end is touched send to winning screen
             void this.endGame(GameEnum.WIN);
         } else if (obstacle.name === Objects.GLOVES) {
             //* If gloves is picked up destroy the asset


### PR DESCRIPTION
# Pull request type

-   [X] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, renaming)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] Documentation content changes
-   [ ] E2E Test(s)
-   [ ] Other (please describe):

# What is the current behavior?
When colliding into a cheesesteak at full health, it results in damage.

# What is the new behavior?
- Update conditionals to only inflict damage on non-cheesesteak items.
- Add a new evaluator to handle if obstacle is a cheesesteak and the player is a full health, to _only_ remove the obstacle. 

# Does this introduce a breaking change?

-   [ ] Yes
-   [X] No

# Other information
