### PR TITLE
fix(world): update obstacleHanlder for invulnerable effect

### DIFF
--- a/apps/rock-the-steps/src/app/result-screen/result-screen.component.scss
+++ b/apps/rock-the-steps/src/app/result-screen/result-screen.component.scss
@@ -30,6 +30,7 @@ p.win-points {
 }
 
 .navigation-options {
-  float: right;
-  padding-right: 2.25rem;
+  bottom: 2rem;
+  position: absolute;
+  right: 2rem;
 }

--- a/libs/shared/phaser-singleton/src/lib/scenes/world.scene.ts
+++ b/libs/shared/phaser-singleton/src/lib/scenes/world.scene.ts
@@ -322,6 +322,8 @@ export class WorldScene extends Phaser.Scene {
             obstacle.destroy();
             this.obstacleGroup.remove(obstacle);
             this.character.makeInvulnerable(this);
+        } else if (this.character.isInvulnerable) {
+            this.obstacleGroup.remove(obstacle);
         } else if (obstacle.name !== Objects.CHEESESTEAK && !this.character.isDamaged && !this.character.isInvulnerable) {
             obstacle.destroy();
             this.receiveDamage();


### PR DESCRIPTION
# Pull request type

-   [X] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, renaming)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] Documentation content changes
-   [ ] E2E Test(s)
-   [ ] Other (please describe):

# What is the current behavior?
When invulnerable the objects are not destroyed, so the player runs into them and gets stuck. 

# What is the new behavior?
Updated the handler for when there is a collision and the player is invulnerable to only remove the object.

# Does this introduce a breaking change?

-   [ ] Yes
-   [X] No

# Other information
