### PR TITLE
fix/stage-select-footer

### DIFF
--- a/apps/rock-the-steps/src/app/stage-select/stage-select.component.html
+++ b/apps/rock-the-steps/src/app/stage-select/stage-select.component.html
@@ -22,10 +22,7 @@
                 <ion-icon name="star" [ngClass]="{ 'is-completed': progression[4].hasCompletedOnce }"></ion-icon>
                 <ion-icon name="star" [ngClass]="{ 'is-completed': progression[5].hasCompletedOnce }"></ion-icon>
             </ion-badge>
-            <img
-                [src]="allPointsEarned > 1000 && progression[2].hasCompletedOnce ? '/assets/stages/stage2.png' : '/assets/stages/stage2locked.png'"
-                alt="image_stage_2"
-            />
+            <img [src]="allPointsEarned > 1000 && progression[2].hasCompletedOnce ? '/assets/stages/stage2.png' : '/assets/stages/stage2locked.png'" alt="image_stage_2" />
             <h6 *ngIf="allPointsEarned < 1000 || !progression[2].hasCompletedOnce">Unlock at 1,000 Points</h6>
         </div>
         <div class="stage" (click)="allPointsEarned > 2000 && progression[5].hasCompletedOnce ? selectLevel(levelsEnum.NIGHT) : null">
@@ -34,10 +31,7 @@
                 <ion-icon name="star" [ngClass]="{ 'is-completed': progression[7].hasCompletedOnce }"></ion-icon>
                 <ion-icon name="star" [ngClass]="{ 'is-completed': progression[8].hasCompletedOnce }"></ion-icon>
             </ion-badge>
-            <img
-                [src]="allPointsEarned > 2000 && progression[5].hasCompletedOnce ? '/assets/stages/stage3.png' : '/assets/stages/stage3locked.png'"
-                alt="image_stage_3"
-            />
+            <img [src]="allPointsEarned > 2000 && progression[5].hasCompletedOnce ? '/assets/stages/stage3.png' : '/assets/stages/stage3locked.png'" alt="image_stage_3" />
             <h6 *ngIf="allPointsEarned < 2000 || !progression[5].hasCompletedOnce">Unlock at 2,000 Points</h6>
         </div>
         <div class="stage" (click)="allPointsEarned > 3000 && progression[8].hasCompletedOnce ? selectLevel(levelsEnum.KELLY_DRIVE) : null">
@@ -46,10 +40,7 @@
                 <ion-icon name="star" [ngClass]="{ 'is-completed': progression[10].hasCompletedOnce }"></ion-icon>
                 <ion-icon name="star" [ngClass]="{ 'is-completed': progression[11].hasCompletedOnce }"></ion-icon>
             </ion-badge>
-            <img
-                [src]="allPointsEarned > 3000 && progression[8].hasCompletedOnce ? '/assets/stages/stage4.png' : '/assets/stages/stage4locked.png'"
-                alt="image_stage_4"
-            />
+            <img [src]="allPointsEarned > 3000 && progression[8].hasCompletedOnce ? '/assets/stages/stage4.png' : '/assets/stages/stage4locked.png'" alt="image_stage_4" />
             <h6 *ngIf="allPointsEarned < 3000 || !progression[8].hasCompletedOnce">Unlock at 3,000 Points</h6>
         </div>
         <div class="stage" (click)="allPointsEarned > 4000 && progression[11].hasCompletedOnce ? selectLevel(levelsEnum.RITTEN_HOUSE) : null">
@@ -58,10 +49,7 @@
                 <ion-icon name="star" [ngClass]="{ 'is-completed': progression[13].hasCompletedOnce }"></ion-icon>
                 <ion-icon name="star" [ngClass]="{ 'is-completed': progression[14].hasCompletedOnce }"></ion-icon>
             </ion-badge>
-            <img
-                [src]="allPointsEarned > 4000 && progression[11].hasCompletedOnce ? '/assets/stages/stage5.png' : '/assets/stages/stage5locked.png'"
-                alt="image_stage_5"
-            />
+            <img [src]="allPointsEarned > 4000 && progression[11].hasCompletedOnce ? '/assets/stages/stage5.png' : '/assets/stages/stage5locked.png'" alt="image_stage_5" />
             <h6 *ngIf="allPointsEarned < 4000 || progression[11].hasCompletedOnce === false">Unlock at 4,000 Points</h6>
         </div>
         <div class="stage" (click)="allPointsEarned > 105000 && progression[14].hasCompletedOnce ? selectLevel(levelsEnum.CHINA_TOWN) : null">
@@ -70,16 +58,15 @@
                 <ion-icon name="star" [ngClass]="{ 'is-completed': progression[16].hasCompletedOnce }"></ion-icon>
                 <ion-icon name="star" [ngClass]="{ 'is-completed': progression[17].hasCompletedOnce }"></ion-icon>
             </ion-badge>
-            <img
-                [src]="allPointsEarned > 10000 && progression[14].hasCompletedOnce ? '/assets/stages/stage6.png' : '/assets/stages/stage6locked.png'"
-                alt="image_stage_6"
-            />
+            <img [src]="allPointsEarned > 10000 && progression[14].hasCompletedOnce ? '/assets/stages/stage6.png' : '/assets/stages/stage6locked.png'" alt="image_stage_6" />
             <h6 *ngIf="allPointsEarned < 10000 || !progression[14].hasCompletedOnce">Unlock at 10,000 Points</h6>
         </div>
     </div>
-</ion-content>
-<ion-footer mode="ios">
-    <div class="user-information-container">
-        <h2 class="user-points">Current Points: <strong>{{ allPointsEarned | number:'1.0':'en-US' }}</strong></h2>
+    <div class="footer">
+        <div class="user-information-container">
+            <h2 class="user-points">
+                Current Points: <strong>{{ allPointsEarned | number : '1.0' : 'en-US' }}</strong>
+            </h2>
+        </div>
     </div>
-</ion-footer>
+</ion-content>

--- a/apps/rock-the-steps/src/app/stage-select/stage-select.component.scss
+++ b/apps/rock-the-steps/src/app/stage-select/stage-select.component.scss
@@ -30,6 +30,7 @@ ion-header > ion-button {
   column-gap: 3rem;
   height: 100%;
   padding: 1rem 4rem;
+  margin: 0 0 10rem;
 }
 
 .stage {
@@ -66,10 +67,6 @@ ion-icon.is-completed {
   color: var(--rts-red);
 }
 
-ion-footer {
-  background: var(--rts-red);
-}
-
 .user-information-container {
   align-items: center;
   display: flex;
@@ -80,4 +77,13 @@ ion-footer {
   color: var(--rts-basic-white);
   font-size: 1.25rem;
   text-align: center;
+}
+
+.footer {
+  background: var(--rts-red);
+  position: fixed;
+  width: 100%;
+  color: var(--rts-basic-white);
+  text-align: center;
+  bottom: -0.0625;
 }

--- a/apps/rock-the-steps/src/app/stage-select/stage-select.component.ts
+++ b/apps/rock-the-steps/src/app/stage-select/stage-select.component.ts
@@ -198,7 +198,7 @@ export class StageSelectComponent implements OnInit {
         if (screen === this.screensEnums.LEADERBOARDS) {
             await this.gameServicesActions.openLeaderboards();
         } else {
-            await this.router.navigate([screen]);
+            await this.router.navigate([screen], { replaceUrl: true });
         }
     }
 }


### PR DESCRIPTION
# Pull request type

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, renaming)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] Documentation content changes
-   [ ] E2E Test(s)
-   [ ] Other (please describe):

# What is the current behavior?
[Task(): when the user goes back from stage select there is a red bar at the bottom of the screen that stays for a few seconds before disappearing](https://openforge.teamwork.com/#/tasks/30120839)

# What is the new behavior?
fix(): ended up removing ion footer to add custom footer

# Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

# Other information
