### PR TITLE
fix(modal): dismiss once connection is restored

### DIFF
--- a/apps/rock-the-steps/src/app/app.component.ts
+++ b/apps/rock-the-steps/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Network } from '@capacitor/network';
 import { ScreenOrientation } from '@capacitor/screen-orientation';
-import { ModalController, Platform } from '@ionic/angular';
+import { Platform } from '@ionic/angular';
 import { PhaserSingletonService } from '@openforge/shared-phaser-singleton';
 
 import { InternetConnectionFailComponent } from './network/internet-connection-fail/internet-connection-fail.component';
@@ -13,7 +13,7 @@ import { ModalService } from './services/modal.service';
     styleUrls: ['app.component.scss'],
 })
 export class AppComponent implements OnDestroy, OnInit {
-    constructor(public phaserInstance: PhaserSingletonService, public platform: Platform, private modalController: ModalController, private modalService: ModalService) {}
+    constructor(public phaserInstance: PhaserSingletonService, public platform: Platform, private modalService: ModalService) {}
 
     async ngOnInit(): Promise<void> {
         if (this.platform.is('capacitor')) {

--- a/apps/rock-the-steps/src/app/app.component.ts
+++ b/apps/rock-the-steps/src/app/app.component.ts
@@ -13,7 +13,6 @@ import { ModalService } from './services/modal.service';
     styleUrls: ['app.component.scss'],
 })
 export class AppComponent implements OnDestroy, OnInit {
-    modalCtrl;
     constructor(public phaserInstance: PhaserSingletonService, public platform: Platform, private modalController: ModalController, private modalService: ModalService) {}
 
     async ngOnInit(): Promise<void> {

--- a/apps/rock-the-steps/src/app/app.component.ts
+++ b/apps/rock-the-steps/src/app/app.component.ts
@@ -5,6 +5,7 @@ import { ModalController, Platform } from '@ionic/angular';
 import { PhaserSingletonService } from '@openforge/shared-phaser-singleton';
 
 import { InternetConnectionFailComponent } from './network/internet-connection-fail/internet-connection-fail.component';
+import { ModalService } from './services/modal.service';
 
 @Component({
     selector: 'openforge-app-root',
@@ -12,13 +13,28 @@ import { InternetConnectionFailComponent } from './network/internet-connection-f
     styleUrls: ['app.component.scss'],
 })
 export class AppComponent implements OnDestroy, OnInit {
-    constructor(public phaserInstance: PhaserSingletonService, public platform: Platform, private modalController: ModalController) {}
+    modalCtrl;
+    constructor(public phaserInstance: PhaserSingletonService, public platform: Platform, private modalController: ModalController, private modalService: ModalService) {}
 
     async ngOnInit(): Promise<void> {
         if (this.platform.is('capacitor')) {
             this.setScreenOrientation();
         }
-        void this.checkInternetConnection();
+
+        const connectionStatus = await Network.getStatus();
+        if (connectionStatus.connectionType === 'none') {
+            void this.showNetworkModal();
+        }
+
+        void Network.addListener('networkStatusChange', status => {
+            if (status.connectionType === 'none') {
+                void this.showNetworkModal();
+            }
+
+            if (status.connectionType !== 'none') {
+                void this.modalService.dismiss();
+            }
+        });
     }
 
     /**
@@ -30,31 +46,14 @@ export class AppComponent implements OnDestroy, OnInit {
     }
 
     /**
-     * * Function to check network status
-     *
-     */
-    private async checkInternetConnection(): Promise<void> {
-        const connectionStatus = await Network.getStatus();
-        if (connectionStatus.connectionType === 'none') {
-            void this.showNetworkModal();
-        }
-        void Network.addListener('networkStatusChange', status => {
-            if (status.connectionType === 'none') {
-                void this.showNetworkModal();
-            }
-        });
-    }
-
-    /**
      * * Function to display Networt Connection Modal
      *
      */
     private async showNetworkModal(): Promise<void> {
-        const modalCtrl = await this.modalController.create({
+        await this.modalService.showModal({
             component: InternetConnectionFailComponent,
-            canDismiss: false,
+            backdropDismiss: false,
         });
-        await modalCtrl.present();
     }
 
     /**

--- a/apps/rock-the-steps/src/app/app.module.ts
+++ b/apps/rock-the-steps/src/app/app.module.ts
@@ -10,13 +10,14 @@ import { HomePageComponent } from './home/home.page';
 import { InternetConnectionFailComponent } from './network/internet-connection-fail/internet-connection-fail.component';
 import { PlayStageComponent } from './play-stage/play-stage.component';
 import { ResultScreenComponent } from './result-screen/result-screen.component';
+import { ModalService } from './services/modal.service';
 import { DifficultSelectModalComponent } from './stage-select/difficult-select-modal/difficult-select-modal.component';
 import { StageSelectComponent } from './stage-select/stage-select.component';
 
 @NgModule({
     declarations: [AppComponent, HomePageComponent, StageSelectComponent, PlayStageComponent, DifficultSelectModalComponent, ResultScreenComponent, InternetConnectionFailComponent],
     imports: [BrowserModule, IonicModule.forRoot(), PhaserSingletonService.forRoot(), AppRoutingModule],
-    providers: [{ provide: RouteReuseStrategy, useClass: IonicRouteStrategy }],
+    providers: [{ provide: RouteReuseStrategy, useClass: IonicRouteStrategy }, ModalService],
     bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/apps/rock-the-steps/src/app/network/internet-connection-fail/internet-connection-fail.component.ts
+++ b/apps/rock-the-steps/src/app/network/internet-connection-fail/internet-connection-fail.component.ts
@@ -3,13 +3,15 @@ import { Router } from '@angular/router';
 import { Network } from '@capacitor/network';
 import { AlertController, LoadingController } from '@ionic/angular';
 
+import { ModalService } from '../../services/modal.service';
+
 @Component({
     selector: 'openforge-internet-connection-fail',
     templateUrl: './internet-connection-fail.component.html',
     styleUrls: ['./internet-connection-fail.component.scss'],
 })
 export class InternetConnectionFailComponent {
-    constructor(private router: Router, private loadingController: LoadingController, private alertController: AlertController) {}
+    constructor(private router: Router, private loadingController: LoadingController, private alertController: AlertController, private modalService: ModalService) {}
 
     /**
      * * Function to retrieve newtork status
@@ -23,9 +25,11 @@ export class InternetConnectionFailComponent {
 
         // * Retrieving network connection
         const networkStatus = await Network.getStatus();
-        if (networkStatus.connectionType === 'none') {
-            void this.loadingController.dismiss();
+
+        if (networkStatus.connectionType !== 'none') {
             void this.router.navigate(['home'], { replaceUrl: true });
+            await this.loadingController.dismiss();
+            await this.modalService.dismiss();
         } else {
             void this.loadingController.dismiss();
             const alertCtrl = await this.alertController.create({

--- a/apps/rock-the-steps/src/app/services/modal.service.ts
+++ b/apps/rock-the-steps/src/app/services/modal.service.ts
@@ -5,7 +5,7 @@ import { ModalController, ModalOptions } from '@ionic/angular';
 @Injectable({ providedIn: 'root' })
 export class ModalService {
     public showingModal = false; //* This flag is used to know if the modal is already displayed
-    private modalElement!: HTMLIonModalElement; // * Used to show modal
+    public modalElement!: HTMLIonModalElement; // * Used to show modal
 
     constructor(private modalController: ModalController) {}
 
@@ -23,9 +23,9 @@ export class ModalService {
     /**
      * * This function dismisses a modal and sets a flag indicating that the modal is no longer showing.
      */
-    public async dismiss(): Promise<void> {
+    public async dismiss(parameters?: object): Promise<void> {
         try {
-            await this.modalElement.dismiss();
+            await this.modalElement.dismiss(parameters);
             this.showingModal = false;
         } catch (e) {
             console.warn('Error with dismissing modal - ', e);

--- a/apps/rock-the-steps/src/app/services/modal.service.ts
+++ b/apps/rock-the-steps/src/app/services/modal.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@angular/core';
+// eslint-disable-next-line import/named
+import { ModalController, ModalOptions } from '@ionic/angular';
+
+@Injectable({ providedIn: 'root' })
+export class ModalService {
+    public showingModal = false; //* This flag is used to know if the modal is already displayed
+    private modalElement!: HTMLIonModalElement; // * Used to show modal
+
+    constructor(private modalController: ModalController) {}
+
+    /**
+     * * Shows modal while data is being loaded
+     */
+    public async showModal(parameters: ModalOptions): Promise<void> {
+        if (!this.showingModal) {
+            this.modalElement = await this.modalController.create(parameters);
+            await this.modalElement.present();
+            this.showingModal = true;
+        }
+    }
+
+    /**
+     * * This function dismisses a modal and sets a flag indicating that the modal is no longer showing.
+     */
+    public async dismiss(): Promise<void> {
+        try {
+            await this.modalElement.dismiss();
+            this.showingModal = false;
+        } catch (e) {
+            console.warn('Error with dismissing modal - ', e);
+        }
+    }
+}

--- a/apps/rock-the-steps/src/app/stage-select/difficult-select-modal/difficult-select-modal.component.ts
+++ b/apps/rock-the-steps/src/app/stage-select/difficult-select-modal/difficult-select-modal.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
-import { ModalController } from '@ionic/angular';
 import { DifficultyEnum } from '@openforge/shared/data-access-model';
+
+import { ModalService } from '../../services/modal.service';
 
 @Component({
     selector: 'openforge-difficult-select-modal',
@@ -10,9 +11,9 @@ import { DifficultyEnum } from '@openforge/shared/data-access-model';
 export class DifficultSelectModalComponent {
     public difficultEnum = DifficultyEnum; // * Difficult enum used to select the difficulty from template
 
-    constructor(private modalController: ModalController) {}
+    constructor(private modalService: ModalService) {}
 
     public async dismissModal(difficult: DifficultyEnum): Promise<void> {
-        await this.modalController.dismiss(difficult, 'confirm');
+        await this.modalService.dismiss({ difficult });
     }
 }

--- a/apps/rock-the-steps/src/app/stage-select/stage-select.component.ts
+++ b/apps/rock-the-steps/src/app/stage-select/stage-select.component.ts
@@ -1,12 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { Preferences } from '@capacitor/preferences';
-import { ModalController } from '@ionic/angular';
 import { DifficultyEnum, GameServicesActions, LevelsEnum, ScreensEnum } from '@openforge/shared/data-access-model';
 import { Stage } from 'libs/shared/data-access-model/src/lib/models/stage.interface';
 import { AudioService } from 'libs/shared/data-access-model/src/lib/services/audio.service';
 
 import { GameEngineSingleton } from '../../../../../libs/shared/data-access-model/src/lib/classes/singletons/game-engine.singleton';
+import { ModalService } from '../services/modal.service';
 import { DifficultSelectModalComponent } from './difficult-select-modal/difficult-select-modal.component';
 
 @Component({
@@ -152,7 +152,7 @@ export class StageSelectComponent implements OnInit {
         },
     ];
 
-    constructor(private router: Router, private modalCtrl: ModalController, private audioService: AudioService) {}
+    constructor(private router: Router, private audioService: AudioService, private modalService: ModalService) {}
 
     async ngOnInit() {
         this.allPointsEarned = Number((await Preferences.get({ key: 'TOTAL_POINTS' })).value);
@@ -173,19 +173,20 @@ export class StageSelectComponent implements OnInit {
     public async selectLevel(level: LevelsEnum): Promise<void> {
         console.log(`Selected ${level}`);
 
-        const modal = await this.modalCtrl.create({
-            component: DifficultSelectModalComponent,
-            cssClass: 'difficult-modal',
-        });
-        await modal.present();
+        await this.modalService
+            .showModal({
+                component: DifficultSelectModalComponent,
+                cssClass: 'difficult-modal',
+            })
+            .then(() => this.modalService.modalElement);
 
-        await modal.onWillDismiss().then(async (action: { role: string; data: number }) => {
+        void this.modalService.modalElement.onWillDismiss().then(async (action: { role: string; data: { difficult: number } }) => {
             if (action.role !== 'backdrop') {
-                GameEngineSingleton.difficult = action.data;
+                GameEngineSingleton.difficult = action.data.difficult;
                 GameEngineSingleton.audioService = this.audioService;
 
                 // * Here load the level
-                void GameEngineSingleton.buildWorld(level, action.data);
+                void GameEngineSingleton.buildWorld(level, action.data.difficult);
                 await this.goTo(ScreensEnum.PLAY_STAGE);
             }
         });


### PR DESCRIPTION
# Pull request type

-   [X] Bugfix
-   [X] Feature
-   [ ] Code style update (formatting, renaming)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] Documentation content changes
-   [ ] E2E Test(s)
-   [ ] Other (please describe):

# What is the current behavior?
- Modal was not dismissing even though logic was calling it to dismiss.

# What is the new behavior?
- Modal correctly dismisses when it is no longer needed.

In addition, added a modal service in general to be able to track the current modal.

# Does this introduce a breaking change?

-   [ ] Yes
-   [X] No

# Other information
