### PR TITLE
feat(audio): add preferences storage for audio toggling

### DIFF
--- a/apps/rock-the-steps/src/app/play-stage/play-stage.component.ts
+++ b/apps/rock-the-steps/src/app/play-stage/play-stage.component.ts
@@ -27,7 +27,7 @@ export class PlayStageComponent implements OnInit {
             } else if (GameEnum.EXIT === value) {
                 await this.router.navigate(['/home'], { replaceUrl: true });
             } else {
-                await this.router.navigate(['/finish'], { queryParams: { r: GameEnum.LOOSE }, replaceUrl: true });
+                await this.router.navigate(['/finish'], { queryParams: { r: GameEnum.LOSE }, replaceUrl: true });
             }
         });
     }

--- a/apps/rock-the-steps/src/app/result-screen/result-screen.component.ts
+++ b/apps/rock-the-steps/src/app/result-screen/result-screen.component.ts
@@ -20,16 +20,31 @@ export class ResultScreenComponent implements OnInit {
     async ngOnInit(): Promise<void> {
         this.activatedRoute.queryParams.subscribe(params => {
             if (params.r === GameEnum.WIN) {
-                void GameEngineSingleton.audioService.playSuccess();
-                this.displayWinBackground = true;
-                void this.updateUserProgression();
-                void setTimeout(() => {
-                    void this.gotoMainMenu();
-                }, TIMEOUT_REDIRECTION_TO_HOME_SCREEN as number);
-            } else if (params.r === GameEnum.LOOSE) {
-                void GameEngineSingleton.audioService.playFail();
+                void this.setWinFunctionality();
+            } else if (params.r === GameEnum.LOSE) {
+                void this.setLoseFunctionality();
             }
         });
+    }
+
+    public async setWinFunctionality(): Promise<void> {
+        const audioPreference = (await Preferences.get({ key: 'AUDIO_ON' })).value;
+        if (audioPreference === 'true') {
+            void GameEngineSingleton.audioService.playSuccess();
+        }
+
+        this.displayWinBackground = true;
+        void this.updateUserProgression();
+        void setTimeout(() => {
+            void this.gotoMainMenu();
+        }, TIMEOUT_REDIRECTION_TO_HOME_SCREEN as number);
+    }
+
+    public async setLoseFunctionality(): Promise<void> {
+        const audioPreference = (await Preferences.get({ key: 'AUDIO_ON' })).value;
+        if (audioPreference === 'true') {
+            void GameEngineSingleton.audioService.playFail();
+        }
     }
 
     /**

--- a/apps/rock-the-steps/src/app/stage-select/difficult-select-modal/difficult-select-modal.component.html
+++ b/apps/rock-the-steps/src/app/stage-select/difficult-select-modal/difficult-select-modal.component.html
@@ -4,7 +4,7 @@
     </div>
     <div class="buttons-container">
         <ion-button id="difficulty-easy" class="rts-button" fill="outline" mode="md" (click)="dismissModal(difficultEnum.EASY)">EASY</ion-button>
-        <ion-button id="difficulty-medium" fill="outline" mode="md" (click)="dismissModal(difficultEnum.MEDIUM)">MEDIUM</ion-button>
-        <ion-button id="difficulty-hard" fill="outline" mode="md" (click)="dismissModal(difficultEnum.HARD)">HARD</ion-button>
+        <ion-button id="difficulty-medium" class="rts-button" fill="outline" mode="md" (click)="dismissModal(difficultEnum.MEDIUM)">MEDIUM</ion-button>
+        <ion-button id="difficulty-hard" class="rts-button" fill="outline" mode="md" (click)="dismissModal(difficultEnum.HARD)">HARD</ion-button>
     </div>
 </div>

--- a/libs/shared/data-access-model/src/lib/enums/game.enum.ts
+++ b/libs/shared/data-access-model/src/lib/enums/game.enum.ts
@@ -1,6 +1,6 @@
 export enum GameEnum {
     WIN = 'WIN',
-    LOOSE = 'LOOSE',
+    LOSE = 'LOSE',
     EXIT = 'EXIT',
     PAUSE = 'PAUSE',
 }

--- a/libs/shared/data-access-model/src/lib/services/audio.service.ts
+++ b/libs/shared/data-access-model/src/lib/services/audio.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { Preferences } from '@capacitor/preferences';
 import { Scene } from 'phaser';
 
 import { BACKGROUND_AUDIO_KEY, JUMP_AUDIO_KEY } from '../constants/game-keys.constants';
@@ -19,11 +20,12 @@ export class AudioService {
      * @param scene as Phaser.Scene
      * @param backgroundKey as string
      */
-    public playBackground(scene: Scene): void {
+    public async playBackground(scene: Scene): Promise<void> {
         this.activeMusic = true;
         this.backgroundAudio = scene.sound.add(BACKGROUND_AUDIO_KEY, { loop: true });
         try {
             this.backgroundAudio.play();
+            await Preferences.set({ key: 'AUDIO_ON', value: 'true' });
         } catch (e) {
             console.error('Error playing background audio', e);
         }
@@ -33,7 +35,7 @@ export class AudioService {
      * * Function to pause background audio file
      *
      */
-    public pauseBackground(): void {
+    public async pauseBackground(): Promise<void> {
         this.activeMusic = false;
         if (this.backgroundAudio) {
             this.backgroundAudio.pause();
@@ -46,9 +48,10 @@ export class AudioService {
      * * Function to resume the background audio file
      *
      */
-    public resumeBackground(): void {
+    public async resumeBackground(): Promise<void> {
         if (this.backgroundAudio) {
             this.backgroundAudio.resume();
+            await Preferences.set({ key: 'AUDIO_ON', value: 'true' });
         } else {
             console.error('No backgroundAudio key was found');
         }

--- a/libs/shared/phaser-singleton/src/lib/scenes/pause.scene.ts
+++ b/libs/shared/phaser-singleton/src/lib/scenes/pause.scene.ts
@@ -53,7 +53,7 @@ export class PauseScene extends Phaser.Scene {
     private resumeGame(): void {
         this.scene.stop(); // Delete modal scene
         this.scene.resume('WorldScene');
-        GameEngineSingleton.audioService.resumeBackground();
+        void GameEngineSingleton.audioService.resumeBackground();
     }
 
     /**

--- a/libs/shared/phaser-singleton/src/lib/scenes/world.scene.ts
+++ b/libs/shared/phaser-singleton/src/lib/scenes/world.scene.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-magic-numbers */
+import { Preferences } from '@capacitor/preferences';
 import {
     BACKGROUND_AUDIO_KEY,
     Bushes,
@@ -121,9 +122,13 @@ export class WorldScene extends Phaser.Scene {
         this.scale.orientation = Phaser.Scale.Orientation.LANDSCAPE; // * We need to set the orientation to landscape for the scene
         this.scale.lockOrientation('landscape');
         this.initializeBasicWorld();
-        createButtons(this, this.character, this.spaceBarKey);
+        void createButtons(this, this.character, this.spaceBarKey);
         createAnimationsCharacter(this.character.sprite);
-        GameEngineSingleton.audioService.playBackground(this);
+
+        const audioPreference = (await Preferences.get({ key: 'AUDIO_ON' })).value;
+        if (audioPreference === 'true' || audioPreference === undefined) {
+            void GameEngineSingleton.audioService.playBackground(this);
+        }
     }
 
     /**
@@ -180,7 +185,7 @@ export class WorldScene extends Phaser.Scene {
             this.character.receiveDamage(this);
             //if no more damage is allowed send out the player!
             if (this.character.damageValue === DAMAGE_MAX_VALUE) {
-                void this.endGame(GameEnum.LOOSE);
+                void this.endGame(GameEnum.LOSE);
             }
             GameEngineSingleton.points -= GameEngineSingleton.points >= DAMAGE_DECREASE_VALUE ? DAMAGE_DECREASE_VALUE : GameEngineSingleton.points;
         }

--- a/libs/shared/phaser-singleton/src/lib/utilities/hud-helper.ts
+++ b/libs/shared/phaser-singleton/src/lib/utilities/hud-helper.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-magic-numbers */
+import { Preferences } from '@capacitor/preferences';
 import {
     BUTTON_JUMP_X,
     BUTTON_LEFT_X,
@@ -28,7 +29,7 @@ import { CONFIG } from '../config';
  *
  * @private
  */
-export function createButtons(scene: Scene, character: Character, spaceBarKey: Phaser.Input.Keyboard.Key): void {
+export async function createButtons(scene: Scene, character: Character, spaceBarKey: Phaser.Input.Keyboard.Key): Promise<void> {
     const buttonLeft = scene.add.sprite(BUTTON_LEFT_X, CONFIG.DEFAULT_HEIGHT - BUTTONS_MOVE_Y, CONTROLS_KEY, LEFT_KEY);
     buttonLeft.setScale(CONFIG.DEFAULT_CONTROL_SCALE);
     buttonLeft.setInteractive();
@@ -58,8 +59,15 @@ export function createButtons(scene: Scene, character: Character, spaceBarKey: P
     pauseButton.setDepth(2);
     pauseButton.on(POINTER_DOWN_EVENT, () => showPauseModal(scene), scene);
 
+    const audioPreference = (await Preferences.get({ key: 'AUDIO_ON' })).value;
+
+    let audioButton = MUTE_BUTTON;
+    if (audioPreference === 'true' || audioPreference === undefined) {
+        audioButton = MUSIC_BUTTON;
+    }
+
     const musicButton = scene.add
-        .image(CONFIG.DEFAULT_WIDTH * 0.85, CONFIG.DEFAULT_HEIGHT * 0.05, MUSIC_BUTTON)
+        .image(CONFIG.DEFAULT_WIDTH * 0.85, CONFIG.DEFAULT_HEIGHT * 0.05, audioButton)
         .setScale(0.1)
         .setOrigin(1, 0)
         .setInteractive();
@@ -72,7 +80,9 @@ export function createButtons(scene: Scene, character: Character, spaceBarKey: P
 export function doJumpMovement(scene: Scene, character: Character): void {
     if (scene) {
         character.isJumping = true;
-        GameEngineSingleton.audioService.playJump(scene);
+        if (GameEngineSingleton.audioService.activeMusic) {
+            GameEngineSingleton.audioService.playJump(scene);
+        }
     }
 }
 
@@ -85,7 +95,9 @@ export function showPauseModal(_scene: Scene): void {
     if (_scene) {
         _scene.scene.pause();
         _scene.scene.run(PAUSE_SCENE);
-        GameEngineSingleton.audioService.pauseBackground();
+        if (GameEngineSingleton.audioService.activeMusic) {
+            void GameEngineSingleton.audioService.pauseBackground();
+        }
     }
 }
 /**
@@ -95,10 +107,10 @@ export function showPauseModal(_scene: Scene): void {
  */
 export function toggleMusic(_scene: Scene, musicButton: Phaser.GameObjects.Image): void {
     if (_scene && GameEngineSingleton.audioService.activeMusic) {
-        GameEngineSingleton.audioService.pauseBackground();
+        void GameEngineSingleton.audioService.pauseBackground();
         musicButton.setTexture(MUTE_BUTTON);
     } else {
-        GameEngineSingleton.audioService.playBackground(_scene);
+        void GameEngineSingleton.audioService.playBackground(_scene);
         musicButton.setTexture(MUSIC_BUTTON);
     }
 }


### PR DESCRIPTION
# Pull request type

-   [X] Bugfix
-   [X] Feature
-   [ ] Code style update (formatting, renaming)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] Documentation content changes
-   [ ] E2E Test(s)
-   [ ] Other (please describe):

# What is the current behavior?
- Audio toggling would not be saved, so if the user selects to mute the app does not remember and then plays audio.

# What is the new behavior?
- We track the audio selection using Capacitor Preferences, then using that value to determine if the user has a preference... if so, what should that do.
- Add missing style for difficulty buttons
- Update a spelling mistake for an ENUM

# Does this introduce a breaking change?

-   [ ] Yes
-   [X] No

# Other information
